### PR TITLE
Feature/sonatype updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.iml
 .idea
+target/

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>bom-parent</artifactId>
 
     <packaging>pom</packaging>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>Reactome BOM Parent</name>
 
     <modules>

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -44,6 +44,33 @@
         <developerConnection>scm:git:ssh://github.com:reactome/reactome-parent.git</developerConnection>
         <url>https://github.com/reactome/reactome-parent/tree/main/boms/</url>
     </scm>
+    <distributionManagement>
+        <!-- EBI repo -->
+        <repository>
+            <id>pst-release</id>
+            <name>EBI Nexus Repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- EBI SNAPSHOT repo -->
+        <snapshotRepository>
+            <uniqueVersion>false</uniqueVersion>
+            <id>pst-snapshots</id>
+            <name>EBI Nexus Snapshots Repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </snapshotRepository>
+    </distributionManagement>
 
     <properties>
         <maven.gpg.version>3.2.8</maven.gpg.version>

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -48,6 +48,7 @@
     <properties>
         <maven.gpg.version>3.2.8</maven.gpg.version>
         <maven.sonatype.central.version>0.8.0</maven.sonatype.central.version>
+        <maven.tidy.version>1.4.0</maven.tidy.version>
     </properties>
 
     <build>
@@ -78,6 +79,22 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                 </configuration>
+            </plugin>
+
+            <!-- Standardizes layout of pom.xml file -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>tidy-maven-plugin</artifactId>
+                <version>${maven.tidy.version}</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -1,18 +1,49 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.reactome.maven</groupId>
     <artifactId>bom-parent</artifactId>
-
-    <packaging>pom</packaging>
     <version>1.0.0</version>
+    <packaging>pom</packaging>
+
     <name>Reactome BOM Parent</name>
+    <description>Reactome BOM aims to centralise dependencies management</description>
+    <url>https://github.com/reactome/reactome-parent</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>eragueneau</id>
+            <name>Eliot Ragueneau</name>
+            <email>eragueneau@ebi.ac.uk</email>
+            <organization>The European Bioinformatics Institute</organization>
+            <organizationUrl>https://www.ebi.ac.uk/</organizationUrl>
+        </developer>
+        <developer>
+            <id>cqgong</id>
+            <name>Chuqiao Gong</name>
+            <email>cgong@ebi.ac.uk</email>
+            <organization>The European Bioinformatics Institute</organization>
+            <organizationUrl>https://www.ebi.ac.uk/</organizationUrl>
+        </developer>
+    </developers>
 
     <modules>
         <module>reactome-bom</module>
         <module>reactome-pwp-bom</module>
     </modules>
+
+    <scm>
+        <connection>scm:git:git://github.com/reactome/reactome-parent.git</connection>
+        <developerConnection>scm:git:ssh://github.com:reactome/reactome-parent.git</developerConnection>
+        <url>https://github.com/reactome/reactome-parent/tree/main/boms/</url>
+    </scm>
 
     <properties>
         <maven.gpg.version>3.2.8</maven.gpg.version>

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -96,18 +96,6 @@
                 </executions>
             </plugin>
 
-
-            <!-- Allows publishing of SNAPSHOTs and releases to Sonatype staging server for Maven Central -->
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>${maven.sonatype.central.version}</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                </configuration>
-            </plugin>
-
             <!-- Standardizes layout of pom.xml file -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -125,4 +113,30 @@
             </plugin>
         </plugins>
     </build>
+
+    <!-- profile to deploy to Sonatype; invoked by "mvn deploy -Dsonatype-deploy=true" -->
+    <profiles>
+        <profile>
+            <id>sonatype-deploy</id>
+            <activation>
+                <property>
+                    <name>sonatype-deploy</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -19,7 +19,7 @@
         <repository>
             <id>central</id>
             <name>Sonatype Central Repository</name>
-            <url>https://repo1.maven.org/maven2/org/sonatype/central/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2//</url>
         </repository>
         <!-- EBI SNAPSHOT repo -->
         <snapshotRepository>

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>bom-parent</artifactId>
 
     <packaging>pom</packaging>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>Reactome BOM Parent</name>
 
     <modules>
@@ -17,16 +17,16 @@
     <distributionManagement>
         <!-- EBI repo -->
         <repository>
-            <id>pst-release</id>
-            <name>EBI Nexus Repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
+            <id>central</id>
+            <name>Sonatype Central Repository</name>
+            <url>https://repo1.maven.org/maven2/org/sonatype/central/</url>
         </repository>
         <!-- EBI SNAPSHOT repo -->
         <snapshotRepository>
             <uniqueVersion>false</uniqueVersion>
-            <id>pst-snapshots</id>
-            <name>EBI Nexus Snapshots Repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
+            <id>central</id>
+            <name>Sonatype Central Snapshot repository</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -14,20 +14,40 @@
         <module>reactome-pwp-bom</module>
     </modules>
 
-    <distributionManagement>
-        <!-- EBI repo -->
-        <repository>
-            <id>central</id>
-            <name>Sonatype Central Repository</name>
-            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2//</url>
-        </repository>
-        <!-- EBI SNAPSHOT repo -->
-        <snapshotRepository>
-            <uniqueVersion>false</uniqueVersion>
-            <id>central</id>
-            <name>Sonatype Central Snapshot repository</name>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-        </snapshotRepository>
-    </distributionManagement>
+    <properties>
+        <maven.gpg.version>3.2.8</maven.gpg.version>
+        <maven.sonatype.central.version>0.8.0</maven.sonatype.central.version>
+    </properties>
 
+    <build>
+        <plugins>
+            <!-- Signs deployed jar, source jar, and JavaDoc jar with GPG -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>${maven.gpg.version}</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+            <!-- Allows publishing of SNAPSHOTs and releases to Sonatype staging server for Maven Central -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>${maven.sonatype.central.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/boms/reactome-bom/pom.xml
+++ b/boms/reactome-bom/pom.xml
@@ -21,6 +21,12 @@
         <name>The European Bioinformatics Institute</name>
         <url>https://www.ebi.ac.uk/</url>
     </organization>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
 
     <developers>
         <developer>
@@ -29,6 +35,12 @@
             <email>eragueneau@ebi.ac.uk</email>
         </developer>
     </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/reactome/reactome-parent.git</connection>
+        <developerConnection>scm:git:ssh://github.com:reactome/reactome-parent.git</developerConnection>
+        <url>https://github.com/reactome/reactome-parent/tree/main/boms/reactome-bom</url>
+    </scm>
 
     <properties>
         <!--             Internal Library            -->

--- a/boms/reactome-bom/pom.xml
+++ b/boms/reactome-bom/pom.xml
@@ -32,6 +32,15 @@
             <id>eragueneau</id>
             <name>Eliot Ragueneau</name>
             <email>eragueneau@ebi.ac.uk</email>
+            <organization>The European Bioinformatics Institute</organization>
+            <organizationUrl>https://www.ebi.ac.uk/</organizationUrl>
+        </developer>
+        <developer>
+            <id>cqgong</id>
+            <name>Chuqiao Gong</name>
+            <email>cgong@ebi.ac.uk</email>
+            <organization>The European Bioinformatics Institute</organization>
+            <organizationUrl>https://www.ebi.ac.uk/</organizationUrl>
         </developer>
     </developers>
 

--- a/boms/reactome-bom/pom.xml
+++ b/boms/reactome-bom/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.reactome.maven</groupId>
     <artifactId>reactome-bom</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
 
     <name>Reactome BOM</name>
     <packaging>pom</packaging>
@@ -33,41 +33,41 @@
     <properties>
         <!--             Internal Library            -->
 
-        <reactome.reactome-base.version>2.2.3-SNAPSHOT</reactome.reactome-base.version>
-        <reactome.graph-core.version>2.0.9</reactome.graph-core.version>
-        <reactome.analysis-core.version>3.4.9</reactome.analysis-core.version>
-        <reactome.diagram-reader.version>1.2.5</reactome.diagram-reader.version>
-        <reactome.diagram-exporter.version>2.0.12</reactome.diagram-exporter.version>
-        <reactome.search-indexer.version>1.0.9</reactome.search-indexer.version>
-        <reactome.fireworks-exporter.version>1.2.8</reactome.fireworks-exporter.version>
-        <reactome.reaction-exporter.version>1.2.8</reactome.reaction-exporter.version>
-        <reactome.search-core.version>1.4.12</reactome.search-core.version>
-        <reactome.interactor-core.version>1.1.5</reactome.interactor-core.version>
-        <reactome.sbml-exporter.version>2.2.7</reactome.sbml-exporter.version>
-        <reactome.event-pdf.version>1.1.10</reactome.event-pdf.version>
+        <reactome.reactome-base.version>2.2.4-SNAPSHOT</reactome.reactome-base.version>
+        <reactome.graph-core.version>2.0.10</reactome.graph-core.version>
+        <reactome.analysis-core.version>3.5.1</reactome.analysis-core.version>
+        <reactome.diagram-reader.version>1.3.1</reactome.diagram-reader.version>
+        <reactome.diagram-exporter.version>2.1.1</reactome.diagram-exporter.version>
+        <reactome.search-indexer.version>1.1.1</reactome.search-indexer.version>
+        <reactome.fireworks-exporter.version>1.3.1</reactome.fireworks-exporter.version>
+        <reactome.reaction-exporter.version>1.3.1</reactome.reaction-exporter.version>
+        <reactome.search-core.version>1.5.1</reactome.search-core.version>
+        <reactome.interactor-core.version>1.2.1</reactome.interactor-core.version>
+        <reactome.sbml-exporter.version>2.3.1</reactome.sbml-exporter.version>
+        <reactome.event-pdf.version>1.2.1</reactome.event-pdf.version>
         <reactome.reactome-utils.version>1.1.5</reactome.reactome-utils.version>
-        <reactome.analysis-report.version>1.2.8</reactome.analysis-report.version>
+        <reactome.analysis-report.version>1.3.1</reactome.analysis-report.version>
 
         <!--            Exterior Endpoints           -->
 
-        <reactome.content-service.version>2.1.11</reactome.content-service.version>
-        <reactome.analysis-service.version>3.1.8</reactome.analysis-service.version>
+        <reactome.content-service.version>2.1.12</reactome.content-service.version>
+        <reactome.analysis-service.version>3.1.9</reactome.analysis-service.version>
         <reactome.data-content.version>2.0.10</reactome.data-content.version>
         <reactome.report-logger.version>1.1.6</reactome.report-logger.version>
         <reactome.experiment-digester.version>1.0.7</reactome.experiment-digester.version>
         <reactome.disease-digester.version>1.2.5</reactome.disease-digester.version>
         <reactome.popular-pathways.version>1.1.7</reactome.popular-pathways.version>
-        <reactome.restful-api.version>0.0.5</reactome.restful-api.version>
+        <reactome.restful-api.version>0.0.6</reactome.restful-api.version>
 
 
         <!--             Release Pipeline            -->
 
-        <reactome.graph-qa.version>1.1.7</reactome.graph-qa.version>
+        <reactome.graph-qa.version>1.2.1</reactome.graph-qa.version>
         <reactome.graph-importer.version>2.0.7</reactome.graph-importer.version>
-        <reactome.diagram-converter.version>3.0.7</reactome.diagram-converter.version>
-        <reactome.fireworks-layout.version>3.0.7</reactome.fireworks-layout.version>
-        <reactome.data-export.version>2.0.7</reactome.data-export.version>
-        <reactome.interaction-exporter.version>2.0.7</reactome.interaction-exporter.version>
+        <reactome.diagram-converter.version>3.1.0</reactome.diagram-converter.version>
+        <reactome.fireworks-layout.version>3.1.0</reactome.fireworks-layout.version>
+        <reactome.data-export.version>2.1.1</reactome.data-export.version>
+        <reactome.interaction-exporter.version>2.1.0</reactome.interaction-exporter.version>
     </properties>
 
     <dependencyManagement>

--- a/boms/reactome-bom/pom.xml
+++ b/boms/reactome-bom/pom.xml
@@ -49,6 +49,33 @@
         <developerConnection>scm:git:ssh://github.com:reactome/reactome-parent.git</developerConnection>
         <url>https://github.com/reactome/reactome-parent/tree/main/boms/reactome-bom</url>
     </scm>
+    <distributionManagement>
+        <!-- EBI repo -->
+        <repository>
+            <id>pst-release</id>
+            <name>EBI Nexus Repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- EBI SNAPSHOT repo -->
+        <snapshotRepository>
+            <uniqueVersion>false</uniqueVersion>
+            <id>pst-snapshots</id>
+            <name>EBI Nexus Snapshots Repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </snapshotRepository>
+    </distributionManagement>
 
     <properties>
         <!--             Internal Library            -->

--- a/boms/reactome-bom/pom.xml
+++ b/boms/reactome-bom/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.reactome.maven</groupId>
     <artifactId>reactome-bom</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.6-SNAPSHOT</version>
 
     <name>Reactome BOM</name>
     <packaging>pom</packaging>

--- a/boms/reactome-bom/pom.xml
+++ b/boms/reactome-bom/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -10,11 +10,10 @@
 
     <groupId>org.reactome.maven</groupId>
     <artifactId>reactome-bom</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
-
-    <name>Reactome BOM</name>
+    <version>1.0.6</version>
     <packaging>pom</packaging>
 
+    <name>Reactome BOM</name>
     <description>Reactome BOM aims to centralise dependencies management</description>
     <url>https://github.com/reactome/reactome-parent</url>
     <organization>
@@ -257,13 +256,8 @@
                 <artifactId>interaction-exporter</artifactId>
                 <version>${reactome.interaction-exporter.version}</version>
             </dependency>
-
-
-
-
         </dependencies>
     </dependencyManagement>
-
 
     <repositories>
         <!-- EBI repo -->

--- a/boms/reactome-bom/pom.xml
+++ b/boms/reactome-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.reactome.maven</groupId>
         <artifactId>bom-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <groupId>org.reactome.maven</groupId>

--- a/boms/reactome-bom/pom.xml
+++ b/boms/reactome-bom/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <!--             Internal Library            -->
 
-        <reactome.reactome-base.version>2.2.4-SNAPSHOT</reactome.reactome-base.version>
+        <reactome.reactome-base.version>2.0.0</reactome.reactome-base.version>
         <reactome.graph-core.version>2.0.10</reactome.graph-core.version>
         <reactome.analysis-core.version>3.5.1</reactome.analysis-core.version>
         <reactome.diagram-reader.version>1.3.1</reactome.diagram-reader.version>

--- a/boms/reactome-bom/pom.xml
+++ b/boms/reactome-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.reactome.maven</groupId>
         <artifactId>bom-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.reactome.maven</groupId>
@@ -279,23 +279,4 @@
             </snapshots>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <!--Configures the distribution to nexus repository. mvn:deploy -->
-        <!-- EBI repo -->
-        <repository>
-            <id>pst-release</id>
-            <name>EBI Nexus Repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
-        </repository>
-        <!-- EBI SNAPSHOT repo -->
-        <snapshotRepository>
-            <uniqueVersion>false</uniqueVersion>
-            <id>pst-snapshots</id>
-            <name>EBI Nexus Snapshots Repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
-
 </project>

--- a/boms/reactome-pwp-bom/pom.xml
+++ b/boms/reactome-pwp-bom/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>reactome-pwp-bom</artifactId>
 
     <packaging>pom</packaging>
-    <version>1.0.4</version>
+    <version>1.0.4-SNAPSHOT</version>
     <name>Reactome PWP BOM</name>
 
     <description>

--- a/boms/reactome-pwp-bom/pom.xml
+++ b/boms/reactome-pwp-bom/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>reactome-pwp-bom</artifactId>
 
     <packaging>pom</packaging>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <name>Reactome PWP BOM</name>
 
     <description>
@@ -33,23 +33,23 @@
     </developers>
 
     <properties>
-        <pwp.scroller.version>1.1.3</pwp.scroller.version>
-        <pwp.carrousel.version>1.1.6</pwp.carrousel.version>
-        <pwp.quadtree.version>1.3.3</pwp.quadtree.version>
+        <pwp.scroller.version>1.1.4</pwp.scroller.version>
+        <pwp.carrousel.version>1.1.7</pwp.carrousel.version>
+        <pwp.quadtree.version>1.3.4</pwp.quadtree.version>
 
-        <pwp.model.version>2.2.4</pwp.model.version>
-        <pwp.analysis-client.version>2.0.4</pwp.analysis-client.version>
+        <pwp.model.version>2.2.6</pwp.model.version>
+        <pwp.analysis-client.version>2.0.5</pwp.analysis-client.version>
 
-        <pwp.diagram.version>4.1.5</pwp.diagram.version>  <!--diagram-js shares the same version number-->
-        <pwp.fireworks.version>2.0.4</pwp.fireworks.version>   <!--fireworks-js shares the same version number-->
+        <pwp.diagram.version>4.1.6</pwp.diagram.version>  <!--diagram-js shares the same version number-->
+        <pwp.fireworks.version>2.0.5</pwp.fireworks.version>   <!--fireworks-js shares the same version number-->
 
-        <pwp.chebi.version>1.2.4</pwp.chebi.version>
-        <pwp.gxa.version>3.1.3</pwp.gxa.version>
-        <pwp.analytics.version>2.1.3</pwp.analytics.version>
-        <pwp.pdb.version>2.3.5</pwp.pdb.version>
-        <pwp.rhea.version>1.3.5</pwp.rhea.version>
+        <pwp.chebi.version>1.2.5</pwp.chebi.version>
+        <pwp.gxa.version>3.1.4</pwp.gxa.version>
+        <pwp.analytics.version>2.1.4</pwp.analytics.version>
+        <pwp.pdb.version>2.3.6</pwp.pdb.version>
+        <pwp.rhea.version>1.3.6</pwp.rhea.version>
 
-        <pwp.browser.version>3.9.4</pwp.browser.version>
+        <pwp.browser.version>3.9.5</pwp.browser.version>
 
     </properties>
     <dependencyManagement>

--- a/boms/reactome-pwp-bom/pom.xml
+++ b/boms/reactome-pwp-bom/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>reactome-pwp-bom</artifactId>
 
     <packaging>pom</packaging>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4</version>
     <name>Reactome PWP BOM</name>
 
     <description>

--- a/boms/reactome-pwp-bom/pom.xml
+++ b/boms/reactome-pwp-bom/pom.xml
@@ -51,6 +51,33 @@
         <developerConnection>scm:git:ssh://github.com:reactome/reactome-parent.git</developerConnection>
         <url>https://github.com/reactome/reactome-parent/tree/main/boms/reactome-pwp-bom</url>
     </scm>
+    <distributionManagement>
+        <!-- EBI repo -->
+        <repository>
+            <id>pst-release</id>
+            <name>EBI Nexus Repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- EBI SNAPSHOT repo -->
+        <snapshotRepository>
+            <uniqueVersion>false</uniqueVersion>
+            <id>pst-snapshots</id>
+            <name>EBI Nexus Snapshots Repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </snapshotRepository>
+    </distributionManagement>
 
     <properties>
         <pwp.scroller.version>1.1.4</pwp.scroller.version>

--- a/boms/reactome-pwp-bom/pom.xml
+++ b/boms/reactome-pwp-bom/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -10,11 +10,10 @@
 
     <groupId>org.reactome.maven</groupId>
     <artifactId>reactome-pwp-bom</artifactId>
-
-    <packaging>pom</packaging>
     <version>1.0.4</version>
-    <name>Reactome PWP BOM</name>
+    <packaging>pom</packaging>
 
+    <name>Reactome PWP BOM</name>
     <description>
         Reactome PWP BOM aims to centralise dependencies management for Pathway Portal
     </description>
@@ -35,6 +34,15 @@
             <id>eragueneau</id>
             <name>Eliot Ragueneau</name>
             <email>eragueneau@ebi.ac.uk</email>
+            <organization>The European Bioinformatics Institute</organization>
+            <organizationUrl>https://www.ebi.ac.uk/</organizationUrl>
+        </developer>
+        <developer>
+            <id>cqgong</id>
+            <name>Chuqiao Gong</name>
+            <email>cgong@ebi.ac.uk</email>
+            <organization>The European Bioinformatics Institute</organization>
+            <organizationUrl>https://www.ebi.ac.uk/</organizationUrl>
         </developer>
     </developers>
 
@@ -64,6 +72,7 @@
         <pwp.browser.version>3.9.5</pwp.browser.version>
 
     </properties>
+
     <dependencyManagement>
         <dependencies>
             <!--      ABSTRACT UI      -->
@@ -163,7 +172,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
 
     <repositories>
         <!-- EBI repo -->

--- a/boms/reactome-pwp-bom/pom.xml
+++ b/boms/reactome-pwp-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.reactome.maven</groupId>
         <artifactId>bom-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.reactome.maven</groupId>
@@ -187,21 +187,4 @@
             </snapshots>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <!-- EBI repo -->
-        <repository>
-            <id>pst-release</id>
-            <name>EBI Nexus Repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
-        </repository>
-        <!-- EBI SNAPSHOT repo -->
-        <snapshotRepository>
-            <uniqueVersion>false</uniqueVersion>
-            <id>pst-snapshots</id>
-            <name>EBI Nexus Snapshots Repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
 </project>

--- a/boms/reactome-pwp-bom/pom.xml
+++ b/boms/reactome-pwp-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.reactome.maven</groupId>
         <artifactId>bom-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <groupId>org.reactome.maven</groupId>

--- a/boms/reactome-pwp-bom/pom.xml
+++ b/boms/reactome-pwp-bom/pom.xml
@@ -23,6 +23,12 @@
         <name>The European Bioinformatics Institute</name>
         <url>http://www.ebi.ac.uk/</url>
     </organization>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
 
     <developers>
         <developer>
@@ -31,6 +37,12 @@
             <email>eragueneau@ebi.ac.uk</email>
         </developer>
     </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/reactome/reactome-parent.git</connection>
+        <developerConnection>scm:git:ssh://github.com:reactome/reactome-parent.git</developerConnection>
+        <url>https://github.com/reactome/reactome-parent/tree/main/boms/reactome-pwp-bom</url>
+    </scm>
 
     <properties>
         <pwp.scroller.version>1.1.4</pwp.scroller.version>

--- a/parents/reactome-parent/pom.xml
+++ b/parents/reactome-parent/pom.xml
@@ -789,16 +789,32 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>${maven.sonatype.central.version}</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+
+    <!-- profile to deploy to reactome-parent to Sonatype; invoked by "mvn deploy -Dsonatype-deploy=true" -->
+    <profiles>
+        <profile>
+            <id>sonatype-deploy</id>
+            <activation>
+                <property>
+                    <name>sonatype-deploy</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/parents/reactome-parent/pom.xml
+++ b/parents/reactome-parent/pom.xml
@@ -52,6 +52,34 @@
         <url>https://github.com/reactome/reactome-parent/tree/main/parents/reactome-parent</url>
     </scm>
 
+    <distributionManagement>
+        <!-- EBI repo -->
+        <repository>
+            <id>pst-release</id>
+            <name>EBI Nexus Repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- EBI SNAPSHOT repo -->
+        <snapshotRepository>
+            <uniqueVersion>false</uniqueVersion>
+            <id>pst-snapshots</id>
+            <name>EBI Nexus Snapshots Repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </snapshotRepository>
+    </distributionManagement>
+
     <properties>
         <spring-boot.version>2.7.6</spring-boot.version>
         <java.version>11</java.version>

--- a/parents/reactome-parent/pom.xml
+++ b/parents/reactome-parent/pom.xml
@@ -48,8 +48,8 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <reactome.reactome-bom.version>1.0.5</reactome.reactome-bom.version>
-        <reactome.reactome-pwp-bom.version>1.0.3</reactome.reactome-pwp-bom.version>
+        <reactome.reactome-bom.version>1.0.6</reactome.reactome-bom.version>
+        <reactome.reactome-pwp-bom.version>1.0.4</reactome.reactome-pwp-bom.version>
 
         <!--graph core-->
         <logback.version>1.2.11</logback.version> <!--Do not update logback to prevent no log output-->

--- a/parents/reactome-parent/pom.xml
+++ b/parents/reactome-parent/pom.xml
@@ -51,7 +51,6 @@
         <developerConnection>scm:git:ssh://github.com:reactome/reactome-parent.git</developerConnection>
         <url>https://github.com/reactome/reactome-parent/tree/main/parents/reactome-parent</url>
     </scm>
-
     <distributionManagement>
         <!-- EBI repo -->
         <repository>

--- a/parents/reactome-parent/pom.xml
+++ b/parents/reactome-parent/pom.xml
@@ -22,6 +22,12 @@
         <name>The European Bioinformatics Institute</name>
         <url>https://www.ebi.ac.uk/</url>
     </organization>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
 
     <developers>
         <developer>
@@ -30,6 +36,12 @@
             <email>eragueneau@ebi.ac.uk</email>
         </developer>
     </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/reactome/reactome-parent.git</connection>
+        <developerConnection>scm:git:ssh://github.com:reactome/reactome-parent.git</developerConnection>
+        <url>https://github.com/reactome/reactome-parent/tree/main/parents/reactome-parent</url>
+    </scm>
 
     <properties>
         <spring-boot.version>2.7.6</spring-boot.version>
@@ -768,7 +780,6 @@
                     </execution>
                 </executions>
             </plugin>
-
 
             <plugin>
                 <groupId>org.sonatype.central</groupId>

--- a/parents/reactome-parent/pom.xml
+++ b/parents/reactome-parent/pom.xml
@@ -34,6 +34,15 @@
             <id>eragueneau</id>
             <name>Eliot Ragueneau</name>
             <email>eragueneau@ebi.ac.uk</email>
+            <organization>The European Bioinformatics Institute</organization>
+            <organizationUrl>https://www.ebi.ac.uk/</organizationUrl>
+        </developer>
+        <developer>
+            <id>cqgong</id>
+            <name>Chuqiao Gong</name>
+            <email>cgong@ebi.ac.uk</email>
+            <organization>The European Bioinformatics Institute</organization>
+            <organizationUrl>https://www.ebi.ac.uk/</organizationUrl>
         </developer>
     </developers>
 

--- a/parents/reactome-parent/pom.xml
+++ b/parents/reactome-parent/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>reactome-parent</artifactId>
 
     <packaging>pom</packaging>
-    <version>1.0.6</version>
+    <version>1.0.6-SNAPSHOT</version>
     <name>Reactome Parent</name>
 
     <description>
@@ -181,7 +181,7 @@
         <maven.war.version>2.6</maven.war.version>
         <maven.gpg.version>3.2.8</maven.gpg.version>
         <maven.tidy.version>1.4.0</maven.tidy.version>
-        <nexus-staging-maven-plugin>1.7.0</nexus-staging-maven-plugin>
+        <maven.sonatype.central.version>0.8.0</maven.sonatype.central.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -660,6 +660,100 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <extensions>true</extensions>
+                <version>${maven.deploy.version}</version>
+            </plugin>
+
+            <!-- Generate JavaDoc jar file -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Signs deployed jar, source jar, and JavaDoc jar with GPG -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>${maven.gpg.version}</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Allows "release" mvn goal to deploy a SNAPSHOT or version release to Sonatype -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven.release.version}</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>tidy-maven-plugin</artifactId>
+                <version>${maven.tidy.version}</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>${maven.sonatype.central.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <repositories>
         <!-- EBI repo -->
@@ -687,22 +781,4 @@
             </snapshots>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <!-- EBI repo -->
-        <repository>
-            <id>pst-release</id>
-            <name>EBI Nexus Repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
-        </repository>
-        <!-- EBI SNAPSHOT repo -->
-        <snapshotRepository>
-            <uniqueVersion>false</uniqueVersion>
-            <id>pst-snapshots</id>
-            <name>EBI Nexus Snapshots Repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
-
 </project>

--- a/parents/reactome-parent/pom.xml
+++ b/parents/reactome-parent/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -10,11 +10,10 @@
 
     <groupId>org.reactome.maven</groupId>
     <artifactId>reactome-parent</artifactId>
-
-    <packaging>pom</packaging>
     <version>1.0.6-SNAPSHOT</version>
-    <name>Reactome Parent</name>
+    <packaging>pom</packaging>
 
+    <name>Reactome Parent</name>
     <description>
         Reactome Parent aims to centralise dependencies management
     </description>
@@ -183,6 +182,7 @@
         <maven.tidy.version>1.4.0</maven.tidy.version>
         <maven.sonatype.central.version>0.8.0</maven.sonatype.central.version>
     </properties>
+
     <dependencyManagement>
         <dependencies>
 
@@ -660,6 +660,33 @@
         </dependencies>
     </dependencyManagement>
 
+    <repositories>
+        <!-- EBI repo -->
+        <repository>
+            <id>nexus-ebi-repo</id>
+            <name>The EBI internal repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-repo/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- EBI SNAPSHOT repo -->
+        <repository>
+            <id>nexus-ebi-snapshot-repo</id>
+            <name>The EBI internal snapshot repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>
@@ -754,31 +781,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <!-- EBI repo -->
-        <repository>
-            <id>nexus-ebi-repo</id>
-            <name>The EBI internal repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-repo/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <!-- EBI SNAPSHOT repo -->
-        <repository>
-            <id>nexus-ebi-snapshot-repo</id>
-            <name>The EBI internal snapshot repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/parents/reactome-parent/pom.xml
+++ b/parents/reactome-parent/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>reactome-parent</artifactId>
 
     <packaging>pom</packaging>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <name>Reactome Parent</name>
 
     <description>
@@ -168,18 +168,20 @@
         <maven.failsafe.version>2.22.2</maven.failsafe.version>
         <maven.resources.version>3.2.0</maven.resources.version>
         <maven.jar.version>3.2.0</maven.jar.version>
-        <maven.source.version>3.2.1</maven.source.version>
+        <maven.source.version>3.3.1</maven.source.version>
         <maven.aspectj.version>1.4</maven.aspectj.version>
         <maven.assembly.version>3.3.0</maven.assembly.version>
         <maven.deploy.version>3.0.0-M1</maven.deploy.version>
         <maven.install.version>3.0.0-M1</maven.install.version>
-        <maven.javadoc.version>2.10.3</maven.javadoc.version>
+        <maven.javadoc.version>3.11.2</maven.javadoc.version>
         <maven.site.version>3.5.1</maven.site.version>
         <maven.info.report.version>3.1.1</maven.info.report.version>
         <maven.pmd.version>3.14.0</maven.pmd.version>
-        <maven.release.version>3.0.0-M1</maven.release.version>
+        <maven.release.version>3.3.1</maven.release.version>
         <maven.war.version>2.6</maven.war.version>
-
+        <maven.gpg.version>3.2.8</maven.gpg.version>
+        <maven.tidy.version>1.4.0</maven.tidy.version>
+        <nexus-staging-maven-plugin>1.7.0</nexus-staging-maven-plugin>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/parents/reactome-parent/pom.xml
+++ b/parents/reactome-parent/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.reactome.maven</groupId>
     <artifactId>reactome-parent</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.6</version>
     <packaging>pom</packaging>
 
     <name>Reactome Parent</name>

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -41,8 +41,8 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <reactome.reactome-bom.version>1.0.3</reactome.reactome-bom.version>
-        <reactome.reactome-pwp-bom.version>1.0.3</reactome.reactome-pwp-bom.version>
+        <reactome.reactome-bom.version>1.0.6</reactome.reactome-bom.version>
+        <reactome.reactome-pwp-bom.version>1.0.4</reactome.reactome-pwp-bom.version>
 
         <!--scroller-->
         <gwtVersion>2.9.0</gwtVersion>

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -28,6 +28,15 @@
             <id>eragueneau</id>
             <name>Eliot Ragueneau</name>
             <email>eragueneau@ebi.ac.uk</email>
+            <organization>The European Bioinformatics Institute</organization>
+            <organizationUrl>https://www.ebi.ac.uk/</organizationUrl>
+        </developer>
+        <developer>
+            <id>cqgong</id>
+            <name>Chuqiao Gong</name>
+            <email>cgong@ebi.ac.uk</email>
+            <organization>The European Bioinformatics Institute</organization>
+            <organizationUrl>https://www.ebi.ac.uk/</organizationUrl>
         </developer>
     </developers>
 

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -77,7 +77,7 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <reactome.reactome-bom.version>1.0.6</reactome.reactome-bom.version>
+        <reactome.reactome-bom.version>1.0.5</reactome.reactome-bom.version>
         <reactome.reactome-pwp-bom.version>1.0.4</reactome.reactome-pwp-bom.version>
 
         <!--scroller-->
@@ -112,6 +112,8 @@
         <!--rhea-->
         <!--shared dependencies-->
 
+        <reactome.reactome-utils.version>1.1.5</reactome.reactome-utils.version>
+
         <!--maven build and plugins-->
         <maven.jar.version>3.2.0</maven.jar.version>
         <gwt.maven.version>1.0-rc-6</gwt.maven.version>
@@ -145,6 +147,56 @@
                 <version>${reactome.reactome-pwp-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-user</artifactId>
+                <version>${gwtVersion}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-codeserver</artifactId>
+                <version>${gwtVersion}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-webapp</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-servlets</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>apache-jsp</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty.websocket</groupId>
+                        <artifactId>websocket-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>apache-jsp</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-servlet</artifactId>
+                <version>${gwtVersion}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.reactome.server.utils</groupId>
+                <artifactId>reactome-utils</artifactId>
+                <version>${reactome.reactome-utils.version}</version>
             </dependency>
 
             <dependency>

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -318,6 +318,15 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <extensions>true</extensions>
                 <version>${maven.deploy.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <!-- Generate JavaDoc jar file -->

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>reactome-pwp-parent</artifactId>
 
     <packaging>pom</packaging>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <name>Reactome PWP Parent</name>
 
     <description>
@@ -69,11 +69,15 @@
         <maven.jar.version>3.2.0</maven.jar.version>
         <gwt.maven.version>1.0-rc-6</gwt.maven.version>
         <maven.war.version>3.3.1</maven.war.version>
-        <maven.source.version>3.2.1</maven.source.version>
+        <maven.source.version>3.3.1</maven.source.version>
         <maven.deploy.version>3.0.0-M1</maven.deploy.version>
         <wagon.ssh.version>3.5.3</wagon.ssh.version>
         <maven.compiler.version>3.8.1</maven.compiler.version>
-
+        <maven.release.version>3.3.1</maven.release.version>
+        <maven.gpg.version>3.2.8</maven.gpg.version>
+        <maven.javadoc.version>3.11.2</maven.javadoc.version>
+        <maven.tidy.version>1.4.0</maven.tidy.version>
+        <nexus-staging-maven-plugin>1.7.0</nexus-staging-maven-plugin>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>reactome-pwp-parent</artifactId>
 
     <packaging>pom</packaging>
-    <version>1.0.4</version>
+    <version>1.0.4-SNAPSHOT</version>
     <name>Reactome PWP Parent</name>
 
     <description>
@@ -77,7 +77,7 @@
         <maven.gpg.version>3.2.8</maven.gpg.version>
         <maven.javadoc.version>3.11.2</maven.javadoc.version>
         <maven.tidy.version>1.4.0</maven.tidy.version>
-        <nexus-staging-maven-plugin>1.7.0</nexus-staging-maven-plugin>
+        <maven.sonatype.central.version>0.8.0</maven.sonatype.central.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -169,6 +169,99 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <extensions>true</extensions>
+                <version>${maven.deploy.version}</version>
+            </plugin>
+
+            <!-- Generate JavaDoc jar file -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Signs deployed jar, source jar, and JavaDoc jar with GPG -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>${maven.gpg.version}</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Allows "release" mvn goal to deploy a SNAPSHOT or version release to Sonatype -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven.release.version}</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>tidy-maven-plugin</artifactId>
+                <version>${maven.tidy.version}</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>${maven.sonatype.central.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <repositories>
         <!-- EBI repo -->
@@ -196,22 +289,4 @@
             </snapshots>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <!-- EBI repo -->
-        <repository>
-            <id>pst-release</id>
-            <name>EBI Nexus Repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
-        </repository>
-        <!-- EBI SNAPSHOT repo -->
-        <snapshotRepository>
-            <uniqueVersion>false</uniqueVersion>
-            <id>pst-snapshots</id>
-            <name>EBI Nexus Snapshots Repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
-
 </project>

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -388,17 +388,32 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <!-- Allows publishing of SNAPSHOTs and releases to Sonatype staging server for Maven Central -->
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>${maven.sonatype.central.version}</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+
+    <!-- profile to deploy to reactome-pwp-parent to Sonatype; invoked by "mvn deploy -Dsonatype-deploy=true" -->
+    <profiles>
+        <profile>
+            <id>sonatype-deploy</id>
+            <activation>
+                <property>
+                    <name>sonatype-deploy</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -45,6 +45,33 @@
         <developerConnection>scm:git:ssh://github.com:reactome/reactome-parent.git</developerConnection>
         <url>https://github.com/reactome/reactome-parent/tree/main/parents/reactome-pwp-parent</url>
     </scm>
+    <distributionManagement>
+        <!-- EBI repo -->
+        <repository>
+            <id>pst-release</id>
+            <name>EBI Nexus Repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- EBI SNAPSHOT repo -->
+        <snapshotRepository>
+            <uniqueVersion>false</uniqueVersion>
+            <id>pst-snapshots</id>
+            <name>EBI Nexus Snapshots Repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </snapshotRepository>
+    </distributionManagement>
 
     <properties>
         <java.version>11</java.version>

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.reactome.maven</groupId>
     <artifactId>reactome-pwp-parent</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4</version>
     <packaging>pom</packaging>
 
     <name>Reactome PWP Parent</name>
@@ -198,6 +198,7 @@
 
     <build>
         <plugins>
+            <!-- Creates jar file containing source (*.java) files for the project-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -263,6 +264,7 @@
                 </configuration>
             </plugin>
 
+            <!-- Standardizes layout of pom.xml file -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>tidy-maven-plugin</artifactId>
@@ -278,6 +280,7 @@
                 </executions>
             </plugin>
 
+            <!-- Allows publishing of SNAPSHOTs and releases to Sonatype staging server for Maven Central -->
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -1,14 +1,13 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.reactome.maven</groupId>
     <artifactId>reactome-pwp-parent</artifactId>
-
-    <packaging>pom</packaging>
     <version>1.0.4-SNAPSHOT</version>
-    <name>Reactome PWP Parent</name>
+    <packaging>pom</packaging>
 
+    <name>Reactome PWP Parent</name>
     <description>
         Reactome Parent aims to centralise dependencies management
     </description>
@@ -79,6 +78,7 @@
         <maven.tidy.version>1.4.0</maven.tidy.version>
         <maven.sonatype.central.version>0.8.0</maven.sonatype.central.version>
     </properties>
+
     <dependencyManagement>
         <dependencies>
 
@@ -168,6 +168,33 @@
 
         </dependencies>
     </dependencyManagement>
+
+    <repositories>
+        <!-- EBI repo -->
+        <repository>
+            <id>nexus-ebi-repo</id>
+            <name>The EBI internal repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-repo/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- EBI SNAPSHOT repo -->
+        <repository>
+            <id>nexus-ebi-snapshot-repo</id>
+            <name>The EBI internal snapshot repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>
@@ -262,31 +289,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <!-- EBI repo -->
-        <repository>
-            <id>nexus-ebi-repo</id>
-            <name>The EBI internal repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-repo/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <!-- EBI SNAPSHOT repo -->
-        <repository>
-            <id>nexus-ebi-snapshot-repo</id>
-            <name>The EBI internal snapshot repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/parents/reactome-pwp-parent/pom.xml
+++ b/parents/reactome-pwp-parent/pom.xml
@@ -16,6 +16,12 @@
         <name>The European Bioinformatics Institute</name>
         <url>https://www.ebi.ac.uk/</url>
     </organization>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
 
     <developers>
         <developer>
@@ -24,6 +30,12 @@
             <email>eragueneau@ebi.ac.uk</email>
         </developer>
     </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/reactome/reactome-parent.git</connection>
+        <developerConnection>scm:git:ssh://github.com:reactome/reactome-parent.git</developerConnection>
+        <url>https://github.com/reactome/reactome-parent/tree/main/parents/reactome-pwp-parent</url>
+    </scm>
 
     <properties>
         <java.version>11</java.version>


### PR DESCRIPTION
Hi @EliotRagueneau @cqgong,

I've updated the POM and BOM files to go to the next version SNAPSHOT.  The changes include:

- the new versions for the Reactome projects
- some common plugins to be used by all child projects via inheritance
- moving the distribution management to the parent bom so it is inherited (Note: The distribution management section isn't needed anymore for the parent pom files since Sonatype provides a newly released plugin for managing artifact upload: see https://central.sonatype.org/publish/publish-portal-maven/)

If these changes look okay, I'd love to publish the new parent files to Sonatype as soon as we can and start using it in the Reactome projects for those to be released next.

Thanks!